### PR TITLE
Support modes derived from message-mode

### DIFF
--- a/gnus-alias.el
+++ b/gnus-alias.el
@@ -720,7 +720,7 @@ one."
 ;;; **************************************************************************
 (defun gnus-alias-ensure-message-mode ()
   "Assert that the current buffer is a message buffer."
-  (when (not (eq major-mode 'message-mode))
+  (when (not (derived-mode-p 'message-mode))
     (gnus-alias-error "Must be in `message-mode'.? ")))
 
 ;;; **************************************************************************


### PR DESCRIPTION
Notmuch (and perhaps other mailers) offers a derived mode
(notmuch-message-mode) which causes gnus-alias-ensure-message-mode to
fail.  Gnus-alias works fine so long as the mode is derived from
message-mode.

Suggested-by: Sanjoy Mahajan sanjoy@olin.edu
Helped-by: David Bremner david@tethera.net
